### PR TITLE
[ACC-3252] Group events by topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the following to your `project.clj` file:
 
 ## Usage
 
-FIXME
+Run test with `lein test`
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,8 @@
                        [org.apache.curator/curator-test "5.0.0"]
                        [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.8.4"]
                        [hikari-cp "2.12.0"]
-                       [b-social/jason "0.1.5"]]
+                       [b-social/jason "0.1.5"]
+                       [faker "0.3.2"]]
                     :eftest {:multithread? false}}}
 
   :cloverage

--- a/test/kafka_event_processor/batch_processing_test.clj
+++ b/test/kafka_event_processor/batch_processing_test.clj
@@ -32,7 +32,6 @@
   (deftest processes-other-topic-events-when-one-topic-fails
     (testing "processes other topic events when one topic fails - last 2 of address-checks are not processed"
       (let [events-atom (:atom @test-system)
-            ^EventHandler event-handler (:event-handler @test-system)
             cases [(test-case :resource-type "liveness-checks")
                    (test-case :resource-type "address-checks")
                    (test-case :resource-type "bankruptcy-checks")

--- a/test/kafka_event_processor/processing_test.clj
+++ b/test/kafka_event_processor/processing_test.clj
@@ -4,22 +4,10 @@
    [kafka-event-processor.test-support.kafka.combined :as kafka]
    [kafka-event-processor.test-support.postgres.database :as database]
    [kafka-event-processor.test-support.system :as system]
-   [kafka-event-processor.test-support.data :as data]
    [kafka-event-processor.test-support.conditional-execution :refer [do-until]]
    [kafka-event-processor.utils.generators :as generators]
    [kafka-event-processor.test-support.kafka.producer :as producer])
   (:import [kafka_event_processor.processor.protocols EventHandler]))
-
-(defn test-case [& {:keys [resource-type throw-error?]}]
-  (let [id (data/random-uuid)
-        brn (str "b-social:" resource-type ":" id)
-        href (data/random-url)]
-    {:resource-type resource-type
-     :topic         resource-type
-     :id            id
-     :brn           brn
-     :href          href
-     :throw-error?  throw-error?}))
 
 (let [database (database/new-database)
       kafka (kafka/new-kafka)

--- a/test/kafka_event_processor/processing_test.clj
+++ b/test/kafka_event_processor/processing_test.clj
@@ -4,10 +4,21 @@
    [kafka-event-processor.test-support.kafka.combined :as kafka]
    [kafka-event-processor.test-support.postgres.database :as database]
    [kafka-event-processor.test-support.system :as system]
+   [kafka-event-processor.test-support.data :as data]
    [kafka-event-processor.test-support.conditional-execution :refer [do-until]]
    [kafka-event-processor.utils.generators :as generators]
    [kafka-event-processor.test-support.kafka.producer :as producer])
   (:import [kafka_event_processor.processor.protocols EventHandler]))
+
+(defn test-case [& {:keys [resource-type]}]
+  (let [id (data/random-uuid)
+        brn (str "b-social:" resource-type ":" id)
+        href (data/random-url)]
+    {:resource-type resource-type
+     :topic         resource-type
+     :id            id
+     :brn           brn
+     :href          href}))
 
 (let [database (database/new-database)
       kafka (kafka/new-kafka)
@@ -50,4 +61,32 @@
           (is (= event-id (get-in cursor [:payload :id])))
           (is (= "test" (:topic cursor)))
           (is (= :main (:processor cursor)))
-          (is (int? (:partition cursor))))))))
+          (is (int? (:partition cursor)))))))
+
+
+  (deftest processes-other-topic-events-when-one-topic-fails
+    (let [events-atom (:atom @test-system)
+          ^EventHandler event-handler (:event-handler @test-system)
+          cases [(test-case :resource-type "liveness-checks")
+                 (test-case :resource-type "address-checks")
+                 (test-case :resource-type "bankruptcy-checks")
+                 (test-case :resource-type "liveness-checks")
+                 (test-case :resource-type "address-checks")
+                 (test-case :resource-type "bankruptcy-checks")
+                 (test-case :resource-type "liveness-checks")
+                 (test-case :resource-type "address-checks")
+                 (test-case :resource-type "bankruptcy-checks")]]
+
+      (doseq [{:keys [topic brn]} cases]
+        (producer/publish-messages kafka topic
+          [{:payload {:brn brn}}]))
+
+      #_(let [read-events (do-until
+                          (fn [] @events-atom)
+                          {:matcher #(= 9 (count %))
+                           :timeout 60000})
+            event (first read-events)]
+        (is (= 9 (count read-events))))
+
+      ))
+  )

--- a/test/kafka_event_processor/test_support/data.clj
+++ b/test/kafka_event_processor/test_support/data.clj
@@ -1,0 +1,22 @@
+(ns kafka-event-processor.test-support.data
+  (:require
+    [clojure.string :refer [join]]
+    [faker.lorem :as lorem]
+    [clj-time.core :as time])
+  (:import
+    [java.util UUID]))
+
+(defn random-uuid []
+  (str (UUID/randomUUID)))
+
+(defn random-created-at []
+  (time/now))
+
+(def url-template "https://%s.com/%s/%s")
+
+(defn random-url
+  ([id]
+    (let [words (take 2 (lorem/words))]
+      (format url-template (first words) (last words) id)))
+  ([]
+    (random-url (random-uuid))))

--- a/test/kafka_event_processor/test_support/kafka/combined.clj
+++ b/test/kafka_event_processor/test_support/kafka/combined.clj
@@ -71,7 +71,7 @@
     (with-source
       (map-source
         {:kafka-main-consumer-group-id     (str (generators/uuid))
-         :kafka-main-consumer-group-topics ["test"]}))))
+         :kafka-main-consumer-group-topics ["test", "liveness-checks", "address-checks", "bankruptcy-checks"]}))))
 
 (def main-processor-configuration
   (define-configuration

--- a/test/kafka_event_processor/test_support/system.clj
+++ b/test/kafka_event_processor/test_support/system.clj
@@ -28,7 +28,9 @@
     true)
   (on-event
     [this processor event _]
-    (swap! (:atom processor) conj event))
+    (if (get-in event [:payload :throw-error?] false)
+      (throw (Exception. "Simulated error"))
+      (swap! (:atom processor) conj event)))
   (on-complete
     [this processor {:keys [topic partition payload]} {:keys [event-processor]}]
     (swap! atom conj {:processor event-processor


### PR DESCRIPTION
Authors: @shamx9ir

Process the batch per topic. This ensures we keep processing other topics, when a message in a topic failed.