### PR TITLE
Config for Kafka partition assignment strategy

### DIFF
--- a/src/kafka_event_processor/kafka/component.clj
+++ b/src/kafka_event_processor/kafka/component.clj
@@ -88,13 +88,14 @@
            auto-offset-reset-config
            ConsumerConfig/ENABLE_AUTO_COMMIT_CONFIG
            enable-auto-commit-config
+           ConsumerConfig/PARTITION_ASSIGNMENT_STRATEGY_CONFIG
+           partition-assignment-strategy
            :security.protocol             security-protocol
            :ssl.truststore.location       ssl-truststore-location
            :ssl.truststore.password       ssl-truststore-password
            :ssl.keystore.location         ssl-keystore-location
            :ssl.keystore.password         ssl-keystore-password
-           :ssl.key.password              ssl-key-password
-           :partition.assignment.strategy partition-assignment-strategy}]
+           :ssl.key.password              ssl-key-password}]
 
       (assoc component
         :consumer-config consumer-config)))

--- a/src/kafka_event_processor/kafka/component.clj
+++ b/src/kafka_event_processor/kafka/component.clj
@@ -74,7 +74,8 @@
                   ssl-truststore-password
                   ssl-keystore-location
                   ssl-keystore-password
-                  ssl-key-password]} configuration
+                  ssl-key-password
+                  partition-assignment-strategy]} configuration
 
           consumer-config
           {ConsumerConfig/BOOTSTRAP_SERVERS_CONFIG
@@ -87,12 +88,13 @@
            auto-offset-reset-config
            ConsumerConfig/ENABLE_AUTO_COMMIT_CONFIG
            enable-auto-commit-config
-           :security.protocol       security-protocol
-           :ssl.truststore.location ssl-truststore-location
-           :ssl.truststore.password ssl-truststore-password
-           :ssl.keystore.location   ssl-keystore-location
-           :ssl.keystore.password   ssl-keystore-password
-           :ssl.key.password        ssl-key-password}]
+           :security.protocol             security-protocol
+           :ssl.truststore.location       ssl-truststore-location
+           :ssl.truststore.password       ssl-truststore-password
+           :ssl.keystore.location         ssl-keystore-location
+           :ssl.keystore.password         ssl-keystore-password
+           :ssl.key.password              ssl-key-password
+           :partition.assignment.strategy partition-assignment-strategy}]
 
       (assoc component
         :consumer-config consumer-config)))

--- a/src/kafka_event_processor/kafka/component.clj
+++ b/src/kafka_event_processor/kafka/component.clj
@@ -49,7 +49,9 @@
     (with-parameter :kafka-ssl-keystore-password
       :default "")
     (with-parameter :kafka-ssl-key-password
-      :default "")))
+      :default "")
+    (with-parameter :kafka-partition-assignment-strategy
+                    :default "org.apache.kafka.clients.consumer.RangeAssignor")))
 
 (defn kafka-configuration
   [prefix]


### PR DESCRIPTION
..defaulting to RangeAssignor so as to be backwards compatible (https://www.conduktor.io/blog/kafka-partition-assignment-strategy/)